### PR TITLE
Move external links from the left nav to a specs page 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,15 +53,6 @@ nav_external_links:
   - title: "IETF datatracker:SCITT"
     url: https://datatracker.ietf.org/wg/scitt/
     hide_icon: false
-  - title: "SCITT Architecture"
-    url: https://datatracker.ietf.org/doc/draft-birkholz-scitt-architecture/
-    hide_icon: false
-  - title: "SCITT Receipts"
-    url: https://datatracker.ietf.org/doc/draft-birkholz-scitt-receipts/
-    hide_icon: false
-  - title: "SCITT Software Use Case"
-    url: https://datatracker.ietf.org/doc/draft-birkholz-scitt-software-use-cases/
-    hide_icon: false
 
 ##############################
 # Just the Docs Theme Settings

--- a/scitt-specs.md
+++ b/scitt-specs.md
@@ -8,6 +8,27 @@ nav_order: 100
 
 The following specifications are part of, or related to the IETF SCITT working group:
 
+- SCITT Use Cases
+  - [IETF datatracker](https://datatracker.ietf.org/doc/draft-ietf-scitt-software-use-cases/){:target="_blank"}
+  - [GitHub Repo](https://github.com/ietf-wg-scitt/draft-ietf-scitt-software-use-cases){:target="_blank"}
+- SCITT Architecture
+  - [IETF datatracker](https://datatracker.ietf.org/doc/draft-ietf-scitt-architecture/){:target="_blank"}
+  - [GitHub Repo](https://github.com/ietf-wg-scitt/draft-ietf-scitt-architecture){:target="_blank"}
+- SCITT Receipts
+  - [IETF datatracker](https://datatracker.ietf.org/doc/draft-birkholz-scitt-receipts/){:target="_blank"}
+  - [GitHub Repo](https://github.com/ietf-scitt/draft-birkholz-scitt-receipts){:target="_blank"}
+- SCITT Reference APIs (SCRAPI)
+  - [GitHub Repo](https://github.com/ietf-scitt/draft-birkholz-scitt-scrapi/){:target="_blank"}
+
+## SCITT Community Projects
+
+- SCITT API Emulator
+  - [GitHub Repo](https://github.com/scitt-community/scitt-api-emulator){:target="_blank"}
+- SCITT REST Emulator
+  - [SCITT.xyz](https://scitt.xyz/){:target="_blank"}
+- SCITT DID Web Demo
+  - [GitHub Repo](https://github.com/scitt-community/did-web-demo){:target="_blank"}
+
 ## SCITT Related Specifications
 
 - [IETF: COSE Specification][cose-spec]{:target="_blank"}


### PR DESCRIPTION
as the list has grown, and I wanted to include both the datatracker page, and the github repo